### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/name/caiyao/microreader/api/guokr/GuokrRequest.java
+++ b/app/src/main/java/name/caiyao/microreader/api/guokr/GuokrRequest.java
@@ -17,6 +17,9 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by 蔡小木 on 2016/3/7 0007.
  */
 public class GuokrRequest {
+
+    private GuokrRequest() {}
+
     protected static final Object monitor = new Object();
     private static final Interceptor REWRITE_CACHE_CONTROL_INTERCEPTOR = new Interceptor() {
         @Override

--- a/app/src/main/java/name/caiyao/microreader/api/itHome/ItHomeRequest.java
+++ b/app/src/main/java/name/caiyao/microreader/api/itHome/ItHomeRequest.java
@@ -19,6 +19,9 @@ import retrofit2.converter.simplexml.SimpleXmlConverterFactory;
  * Created by 蔡小木 on 2016/3/24 0024.
  */
 public class ItHomeRequest {
+
+    private ItHomeRequest() {}
+
     private static final Interceptor REWRITE_CACHE_CONTROL_INTERCEPTOR = new Interceptor() {
         @Override
         public Response intercept(Chain chain) throws IOException {

--- a/app/src/main/java/name/caiyao/microreader/api/util/UtilRequest.java
+++ b/app/src/main/java/name/caiyao/microreader/api/util/UtilRequest.java
@@ -7,6 +7,9 @@ import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
  * Created by 蔡小木 on 2016/3/9 0009.
  */
 public class UtilRequest {
+
+    private UtilRequest() {}
+
     private static UtilApi utilApi = null;
     protected static final Object monitor = new Object();
 

--- a/app/src/main/java/name/caiyao/microreader/api/weiboVideo/VideoRequest.java
+++ b/app/src/main/java/name/caiyao/microreader/api/weiboVideo/VideoRequest.java
@@ -17,6 +17,9 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by YiuChoi on 2016/4/12 0012.
  */
 public class VideoRequest {
+
+    private VideoRequest() {}
+
     private static final Interceptor REWRITE_CACHE_CONTROL_INTERCEPTOR = new Interceptor() {
         @Override
         public Response intercept(Chain chain) throws IOException {

--- a/app/src/main/java/name/caiyao/microreader/api/weixin/TxRequest.java
+++ b/app/src/main/java/name/caiyao/microreader/api/weixin/TxRequest.java
@@ -17,6 +17,9 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by 蔡小木 on 2016/3/4 0004.
  */
 public class TxRequest {
+
+    private TxRequest() {}
+
     private static final Interceptor REWRITE_CACHE_CONTROL_INTERCEPTOR = new Interceptor() {
         @Override
         public Response intercept(Chain chain) throws IOException {

--- a/app/src/main/java/name/caiyao/microreader/api/zhihu/ZhihuRequest.java
+++ b/app/src/main/java/name/caiyao/microreader/api/zhihu/ZhihuRequest.java
@@ -17,6 +17,9 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by 蔡小木 on 2016/3/6 0006.
  */
 public class ZhihuRequest {
+
+    private ZhihuRequest() {}
+
     private static final Interceptor REWRITE_CACHE_CONTROL_INTERCEPTOR = new Interceptor() {
         @Override
         public Response intercept(Chain chain) throws IOException {

--- a/app/src/main/java/name/caiyao/microreader/utils/CacheUtil.java
+++ b/app/src/main/java/name/caiyao/microreader/utils/CacheUtil.java
@@ -38,6 +38,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CacheUtil {
+
+    private CacheUtil() {}
+
     public static final int TIME_HOUR = 60 * 60;
     public static final int TIME_DAY = TIME_HOUR * 24;
     private static final int MAX_SIZE = 1000 * 1000 * 50; // 50 mb

--- a/app/src/main/java/name/caiyao/microreader/utils/ItHomeUtil.java
+++ b/app/src/main/java/name/caiyao/microreader/utils/ItHomeUtil.java
@@ -14,6 +14,8 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public class ItHomeUtil {
 
+    private ItHomeUtil() {}
+
     public static String getMinNewsId(String id) {
         byte[] bytes = new byte[]{-86, -7, -69, -102, -83, -124, -87, -14};
         int i = 0;

--- a/app/src/main/java/name/caiyao/microreader/utils/NetWorkUtil.java
+++ b/app/src/main/java/name/caiyao/microreader/utils/NetWorkUtil.java
@@ -9,6 +9,8 @@ import android.net.NetworkInfo;
  */
 public class NetWorkUtil {
 
+    private NetWorkUtil() {}
+
     /**
      * 判断网络是否可用
      *

--- a/app/src/main/java/name/caiyao/microreader/utils/ScreenUtil.java
+++ b/app/src/main/java/name/caiyao/microreader/utils/ScreenUtil.java
@@ -9,6 +9,8 @@ import android.view.WindowManager;
  */
 public class ScreenUtil {
 
+    private ScreenUtil() {}
+
     public static int getScreenHight(Context context) {
         DisplayMetrics displaymetrics = new DisplayMetrics();
         ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(displaymetrics);

--- a/app/src/main/java/name/caiyao/microreader/utils/SharePreferenceUtil.java
+++ b/app/src/main/java/name/caiyao/microreader/utils/SharePreferenceUtil.java
@@ -10,6 +10,9 @@ import name.caiyao.microreader.R;
  * Created by 蔡小木 on 2016/3/13 0013.
  */
 public class SharePreferenceUtil {
+
+    private SharePreferenceUtil() {}
+
     public static final String SHARED_PREFERENCE_NAME = "micro_reader";
     public static final String IMAGE_DESCRIPTION = "image_description";
     public static final String VIBRANT = "vibrant";

--- a/app/src/main/java/name/caiyao/microreader/utils/WebUtil.java
+++ b/app/src/main/java/name/caiyao/microreader/utils/WebUtil.java
@@ -4,6 +4,9 @@ package name.caiyao.microreader.utils;
  * Created by 蔡小木 on 2016/3/7 0007.
  */
 public class WebUtil {
+
+    private WebUtil() {}
+
     public static final String BASE_URL = "file:///android_asset/";
     public static final String MIME_TYPE = "text/html";
     public static final String ENCODING = "utf-8";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
